### PR TITLE
keywords for npm coc extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
   "engines": {
     "coc": "^0.0.15"
   },
+  "keywords": [
+    "coc.nvim",
+    "languageserver",
+    "pyls"
+  ],
   "scripts": {
     "clean": "rimraf lib",
     "build": "tsc -p tsconfig.json",


### PR DESCRIPTION
fix https://github.com/neoclide/coc.nvim/issues/196, coc-pyls can be listed by `coc.nvim` search in npm.